### PR TITLE
bump actions/setup-haskell: 1.1 -> 1.1.4

### DIFF
--- a/haskell-ci.dhall
+++ b/haskell-ci.dhall
@@ -158,7 +158,7 @@ let checkout =
 let haskellEnv =
       λ(v : VersionInfo.Type) →
         BuildStep.Uses
-          { uses = "actions/setup-haskell@v1.1"
+          { uses = "actions/setup-haskell@v1.1.4"
           , id = Some "setup-haskell-cabal"
           , `with` = Some v
           }


### PR DESCRIPTION
Haskell example explodes badly due to deprecated `add_path`.