### PR TITLE
Add --enable-tests for cabal test as well

### DIFF
--- a/haskell-ci.dhall
+++ b/haskell-ci.dhall
@@ -232,7 +232,7 @@ let stackBuild =
       stackBuildWithFlags
         [ "--bench", "--test", "--no-run-tests", "--no-run-benchmarks" ]
 
-let cabalTest = cabalWithFlags "test" ([] : List Text)
+let cabalTest = cabalWithFlags "test" (["--enable-tests"] : List Text)
 
 let stackTest = stackWithFlags "test" ([] : List Text)
 


### PR DESCRIPTION
Force tests despite plan not including them.


There something weird going on as w/o this I'm getting

```
cabal: Cannot test the package implicit-0.3.0.1 because none of the components
are available to build: the test suite 'test-implicit' is not available
because the solver did not find a plan that included the test suites. Force
the solver to enable this for all packages by adding the line 'tests: True' to
the 'cabal.project.local' file.
```

despite it working when I try it locally with the same Cabal version.

I think https://github.com/haskell/cabal/issues/3923 is related but it might be something else, didn't dig too deep as it looks fine to just force that.

For the record here's the branch with my attempts:
https://github.com/sorki/ImplicitCAD/actions?query=branch%3Aactions