### PR TITLE
haskell: enable Event.pull_request by default

### DIFF
--- a/haskell-ci.dhall
+++ b/haskell-ci.dhall
@@ -78,7 +78,8 @@ let CI =
                   }
               }
           }
-      , default = { name = "Haskell CI", on = [ Event.push ] }
+      , default =
+        { name = "Haskell CI", on = [ Event.push, Event.pull_request ] }
       }
 
 let printGhc =


### PR DESCRIPTION
I think this is the most important event so it should be enabled by default.

Line wrap caused by `dhall format`.